### PR TITLE
Strip output & set proper lib version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     sha256: 01a68a3c8299075ad2b094264bef5109d660f1d53faf614f4f95745ad05f4e3e
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
   script_env:
    - LLVM_VERSION={{ llvm_version }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

As was discovered in https://github.com/intel/intel-graphics-compiler/issues/341 , Release target includes debug information that should be later stripped.

This PR adds proper so versioning and stripping output. This should significantly reduce package size.